### PR TITLE
Update README for Aetherum OS info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # rawdrunner
-Expertimental bare metal loader
+Experimental bare metal loader for Aetherum OS.
+
+Aetherum OS is a hobby operating system focused on exploring low-level system programming. Rawdrunner serves as its initial boot loader and is currently in early development.
+
+## Build / usage hints
+No build or usage instructions are available yet. Future updates will describe how to compile and boot the loader.


### PR DESCRIPTION
## Summary
- fix a typo in the README
- document Aetherum OS purpose
- mention lack of build/usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872f5ff48b0832b992cb5b251c1d68f