### PR TITLE
Implement placeholder sections

### DIFF
--- a/aetherum-kernel/arch/arm64/mod.rs
+++ b/aetherum-kernel/arch/arm64/mod.rs
@@ -1,6 +1,8 @@
 // Stub for future arm64 bring-up
 #![allow(dead_code)]
+use crate::println;
+
 pub fn init(_: &mut bootloader_api::info::BootInfo) {
-    // AIKLE: placeholder — unimplemented for now
-    loop {}
+    // Basic stub for arm64 initialization
+    println!("[arm64] arch init (stub)");
 }

--- a/aetherum-kernel/arch/x86_64/mod.rs
+++ b/aetherum-kernel/arch/x86_64/mod.rs
@@ -1,8 +1,27 @@
-use bootloader_api::info::BootInfo;
 use crate::println;
+use bootloader_api::info::BootInfo;
 
 pub fn init(_boot_info: &mut BootInfo) {
     // Init GDT, IDT, PIC, etc.
     println!("[x86_64] arch init");
-    // AIKLE: placeholder — feed CPU topology to AI
+    // Report simple CPU information
+    unsafe {
+        let id = core::arch::x86_64::__cpuid(0);
+        let bytes = [
+            id.ebx as u8,
+            (id.ebx >> 8) as u8,
+            (id.ebx >> 16) as u8,
+            (id.ebx >> 24) as u8,
+            id.edx as u8,
+            (id.edx >> 8) as u8,
+            (id.edx >> 16) as u8,
+            (id.edx >> 24) as u8,
+            id.ecx as u8,
+            (id.ecx >> 8) as u8,
+            (id.ecx >> 16) as u8,
+            (id.ecx >> 24) as u8,
+        ];
+        let vendor = core::str::from_utf8_unchecked(&bytes);
+        println!("CPU vendor: {}", vendor);
+    }
 }

--- a/aetherum-kernel/memory/mod.rs
+++ b/aetherum-kernel/memory/mod.rs
@@ -1,29 +1,86 @@
 #![allow(dead_code)]
+use bootloader_api::info::{MemoryRegionKind, MemoryRegions};
 use core::ptr::NonNull;
+use spin::Mutex;
 use x86_64::{
     structures::paging::{FrameAllocator, PhysFrame, Size4KiB},
-    VirtAddr, PhysAddr,
+    PhysAddr,
 };
-use spin::Mutex;
 
-pub fn init(_boot_info: &bootloader_api::info::BootInfo) {
-    // TODO: parse memory map & set up frame allocator
-    // AIKLE: placeholder — expose memory telemetry to AI daemon
+/// Simple frame allocator initialized from the bootloader memory map.
+pub struct FrameAlloc {
+    memory_map: &'static MemoryRegions,
+    next: usize,
 }
 
-pub struct FrameAlloc; // AIKLE: placeholder
+unsafe impl Send for FrameAlloc {}
+unsafe impl Sync for FrameAlloc {}
+
+impl FrameAlloc {
+    /// Create a new frame allocator from the bootloader memory map.
+    pub unsafe fn new(memory_map: &'static MemoryRegions) -> Self {
+        Self {
+            memory_map,
+            next: 0,
+        }
+    }
+
+    fn usable_frames(&self) -> impl Iterator<Item = PhysFrame> + '_ {
+        self.memory_map
+            .iter()
+            .filter(|r| r.kind == MemoryRegionKind::Usable)
+            .flat_map(|r| {
+                let start = PhysAddr::new(r.start);
+                let end = PhysAddr::new(r.end - 1);
+                let start_frame = PhysFrame::containing_address(start);
+                let end_frame = PhysFrame::containing_address(end);
+                PhysFrame::range_inclusive(start_frame, end_frame)
+            })
+    }
+}
 
 unsafe impl FrameAllocator<Size4KiB> for FrameAlloc {
     fn allocate_frame(&mut self) -> Option<PhysFrame> {
-        // AIKLE: placeholder — use AI-guided policy in future
-        None
+        let frame = self.usable_frames().nth(self.next)?;
+        self.next += 1;
+        Some(frame)
     }
 }
 
 static HEAP_LOCK: Mutex<()> = Mutex::new(());
+static mut HEAP: [u8; 64 * 4096] = [0; 64 * 4096];
+static mut HEAP_OFF: usize = 0;
 
+/// Very small bump allocator used for kernel allocations.
 pub fn kmalloc(size: usize) -> NonNull<u8> {
     let _g = HEAP_LOCK.lock();
-    // AIKLE: placeholder — delegate to allocator, feed telemetry
-    NonNull::dangling()
+    let size = (size + 7) & !7; // align to 8 bytes
+    unsafe {
+        if HEAP_OFF + size > HEAP.len() {
+            panic!("kmalloc out of memory");
+        }
+        let ptr = HEAP.as_mut_ptr().add(HEAP_OFF);
+        HEAP_OFF += size;
+        NonNull::new(ptr).unwrap()
+    }
+}
+
+static FRAME_ALLOCATOR: Mutex<Option<FrameAlloc>> = Mutex::new(None);
+
+pub fn init(boot_info: &bootloader_api::info::BootInfo) {
+    let regions: &'static MemoryRegions = unsafe { &*(&boot_info.memory_regions as *const _) };
+    let mut alloc = FRAME_ALLOCATOR.lock();
+    *alloc = Some(unsafe { FrameAlloc::new(regions) });
+    // Expose memory statistics via println (telemetry hook)
+    let usable = boot_info
+        .memory_regions
+        .iter()
+        .filter(|r| r.kind == MemoryRegionKind::Usable)
+        .count();
+    crate::println!("[memory] {} usable regions detected", usable);
+}
+
+/// Obtain a mutable reference to the global frame allocator.
+pub fn frame_allocator() -> spin::MutexGuard<'static, Option<FrameAlloc>> {
+    FRAME_ALLOCATOR.lock()
 }

--- a/aetherum-kernel/scheduler/mod.rs
+++ b/aetherum-kernel/scheduler/mod.rs
@@ -1,5 +1,5 @@
-use spin::Mutex;
 use crate::telemetry;
+use spin::Mutex;
 
 type TaskId = usize;
 type TaskFn = fn();
@@ -9,7 +9,7 @@ pub struct Task {
     id: TaskId,
     func: TaskFn,
     // AI-enhanced fields
-    cpu_burst_pred: u32,  // AIKLE: placeholder
+    cpu_burst_pred: u32, // AIKLE: placeholder
 }
 
 static RUNQ: Mutex<[Option<Task>; 64]> = Mutex::new([None; 64]);
@@ -24,12 +24,18 @@ pub fn spawn(f: TaskFn) {
     unsafe {
         let id = NEXT_ID;
         NEXT_ID += 1;
-        q[id] = Some(Task { id, func: f, cpu_burst_pred: 0 });
+        q[id] = Some(Task {
+            id,
+            func: f,
+            cpu_burst_pred: 0,
+        });
     }
 }
 
 pub fn yield_now() {
-    // AIKLE: placeholder — record telemetry before switch
+    // In this toy scheduler we simply record a yield event
+    telemetry::record_task_switch(u32::MAX);
+    core::hint::spin_loop();
 }
 
 pub fn run() -> ! {

--- a/aetherum-kernel/src/lib.rs
+++ b/aetherum-kernel/src/lib.rs
@@ -2,23 +2,44 @@
 #![no_main]
 
 use bootloader_api::{config::BootloaderConfig, entry_point, info::BootInfo};
+use core::fmt::Write;
 use core::panic::PanicInfo;
+use lazy_static::lazy_static;
+use spin::Mutex;
+use uart_16550::SerialPort;
 
 // Re-route modules located outside `src`
+#[path = "../arch/mod.rs"]
+pub mod arch;
 #[path = "../memory/mod.rs"]
 pub mod memory;
 #[path = "../scheduler/mod.rs"]
 pub mod scheduler;
 #[path = "../telemetry/mod.rs"]
 pub mod telemetry;
-#[path = "../arch/mod.rs"]
-pub mod arch;
 
 #[macro_export]
 macro_rules! println {
     ($($arg:tt)*) => {{
-        // AIKLE: placeholder for serial/VGA output
+        $crate::serial::_print(format_args!($($arg)*));
     }};
+}
+
+mod serial {
+    use super::*;
+    lazy_static! {
+        static ref SERIAL1: Mutex<SerialPort> = {
+            let mut sp = unsafe { SerialPort::new(0x3F8) };
+            sp.init();
+            Mutex::new(sp)
+        };
+    }
+
+    pub fn _print(args: core::fmt::Arguments) {
+        use core::fmt::Write;
+        SERIAL1.lock().write_fmt(args).ok();
+        SERIAL1.lock().write_str("\n").ok();
+    }
 }
 
 #[panic_handler]
@@ -46,11 +67,9 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     println!("[Aetherum] boot OK — entering idle loop");
 
     // Spawn an example task
-    scheduler::spawn(|| {
-        loop {
-            println!("hello from task 0!");
-            scheduler::yield_now();
-        }
+    scheduler::spawn(|| loop {
+        println!("hello from task 0!");
+        scheduler::yield_now();
     });
 
     scheduler::run()

--- a/aetherum-kernel/telemetry/mod.rs
+++ b/aetherum-kernel/telemetry/mod.rs
@@ -9,15 +9,36 @@ pub struct Sample {
     arg0: u32,
 }
 
-static RING: Mutex<[Sample; RING_LEN]> = Mutex::new([Sample{tsc:0,event:0,arg0:0}; RING_LEN]);
+static RING: Mutex<[Sample; RING_LEN]> = Mutex::new(
+    [Sample {
+        tsc: 0,
+        event: 0,
+        arg0: 0,
+    }; RING_LEN],
+);
 static mut HEAD: usize = 0;
 
 pub fn init() {
-    // AIKLE: placeholder — maybe map buffer to user space later
+    // Reset ring buffer at boot
+    let mut ring = RING.lock();
+    for slot in ring.iter_mut() {
+        *slot = Sample {
+            tsc: 0,
+            event: 0,
+            arg0: 0,
+        };
+    }
+    unsafe {
+        HEAD = 0;
+    }
 }
 
 pub fn record_task_switch(task_id: u32) {
-    push(Sample { tsc: rdtsc(), event: 1, arg0: task_id });
+    push(Sample {
+        tsc: rdtsc(),
+        event: 1,
+        arg0: task_id,
+    });
 }
 
 fn push(s: Sample) {
@@ -33,6 +54,8 @@ fn push(s: Sample) {
 fn rdtsc() -> u64 {
     let low: u32;
     let high: u32;
-    unsafe { core::arch::asm!("rdtsc", out("eax") low, out("edx") high); }
+    unsafe {
+        core::arch::asm!("rdtsc", out("eax") low, out("edx") high);
+    }
     ((high as u64) << 32) | (low as u64)
 }


### PR DESCRIPTION
## Summary
- fill in functionality for memory, scheduler, telemetry, and architecture modules
- implement serial-based `println!` macro for output
- add simple bump allocator and frame allocator
- log CPU vendor on boot

## Testing
- `cargo check --workspace`
- `cargo check` in `aetherum-kernel`

------
https://chatgpt.com/codex/tasks/task_e_6876485e2db0832b8865938b976ce32c