### PR TITLE
Implement AIKLE scheduler logic

### DIFF
--- a/aetherum-kernel/scheduler/mod.rs
+++ b/aetherum-kernel/scheduler/mod.rs
@@ -1,4 +1,5 @@
 use crate::telemetry;
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use spin::Mutex;
 
 type TaskId = usize;
@@ -9,11 +10,31 @@ pub struct Task {
     id: TaskId,
     func: TaskFn,
     // AI-enhanced fields
-    cpu_burst_pred: u32, // AIKLE: placeholder
+    cpu_burst_pred: u32,
 }
 
 static RUNQ: Mutex<[Option<Task>; 64]> = Mutex::new([None; 64]);
 static mut NEXT_ID: TaskId = 0;
+static CURRENT_TASK: AtomicUsize = AtomicUsize::new(usize::MAX);
+static LAST_START: AtomicU64 = AtomicU64::new(0);
+
+#[inline(always)]
+fn rdtsc() -> u64 {
+    let low: u32;
+    let high: u32;
+    unsafe {
+        core::arch::asm!("rdtsc", out("eax") low, out("edx") high);
+    }
+    ((high as u64) << 32) | (low as u64)
+}
+
+fn update_burst_pred(task: &mut Task, actual: u32) {
+    if task.cpu_burst_pred == 0 {
+        task.cpu_burst_pred = actual;
+    } else {
+        task.cpu_burst_pred = (task.cpu_burst_pred + actual) / 2;
+    }
+}
 
 pub fn init() {
     // nothing yet
@@ -33,20 +54,71 @@ pub fn spawn(f: TaskFn) {
 }
 
 pub fn yield_now() {
-    // In this toy scheduler we simply record a yield event
     telemetry::record_task_switch(u32::MAX);
-    core::hint::spin_loop();
+    let end = rdtsc();
+    let current = CURRENT_TASK.load(Ordering::SeqCst);
+    if current != usize::MAX {
+        let start = LAST_START.load(Ordering::SeqCst);
+        let burst = (end - start) as u32;
+        let mut q = RUNQ.lock();
+        if let Some(task) = q[current].as_mut() {
+            update_burst_pred(task, burst);
+        }
+    }
+    CURRENT_TASK.store(usize::MAX, Ordering::SeqCst);
 }
 
 pub fn run() -> ! {
     loop {
-        // simple round-robin prototype
-        let mut q = RUNQ.lock();
-        for slot in q.iter_mut() {
-            if let Some(task) = slot {
-                (task.func)();
-                telemetry::record_task_switch(task.id as u32); // AI hook
+        let (idx, task) = {
+            let q = RUNQ.lock();
+            let mut best: Option<(usize, Task)> = None;
+            for (i, t) in q.iter().enumerate() {
+                if let Some(task) = t {
+                    if best.map_or(true, |b| task.cpu_burst_pred < b.1.cpu_burst_pred) {
+                        best = Some((i, *task));
+                    }
+                }
+            }
+            match best {
+                Some(v) => v,
+                None => continue,
+            }
+        };
+
+        CURRENT_TASK.store(idx, Ordering::SeqCst);
+        LAST_START.store(rdtsc(), Ordering::SeqCst);
+        (task.func)();
+        let end = rdtsc();
+        let burst = (end - LAST_START.load(Ordering::SeqCst)) as u32;
+        {
+            let mut q = RUNQ.lock();
+            if let Some(t) = q[idx].as_mut() {
+                update_burst_pred(t, burst);
             }
         }
+        telemetry::record_task_switch(task.id as u32);
+        CURRENT_TASK.store(usize::MAX, Ordering::SeqCst);
     }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+
+    #[test]
+    fn test_burst_prediction_update() {
+        let mut task = Task {
+            id: 0,
+            func: test_fn,
+            cpu_burst_pred: 0,
+        };
+        update_burst_pred(&mut task, 10);
+        assert_eq!(task.cpu_burst_pred, 10);
+        update_burst_pred(&mut task, 6);
+        assert_eq!(task.cpu_burst_pred, 8);
+    }
+
+    fn test_fn() {}
 }

--- a/aetherum-kernel/src/lib.rs
+++ b/aetherum-kernel/src/lib.rs
@@ -1,5 +1,5 @@
-#![no_std]
-#![no_main]
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_main)]
 
 use bootloader_api::{config::BootloaderConfig, entry_point, info::BootInfo};
 use core::fmt::Write;
@@ -42,6 +42,7 @@ mod serial {
     }
 }
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     println!("KERNEL PANIC: {info}");
@@ -56,8 +57,10 @@ const BOOT_CFG: BootloaderConfig = {
 };
 
 // Boot entry-point
+#[cfg(not(test))]
 entry_point!(kernel_main, config = &BOOT_CFG);
 
+#[cfg(not(test))]
 fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     arch::init(boot_info);
     memory::init(boot_info);


### PR DESCRIPTION
## Summary
- enhance scheduler with CPU burst prediction logic
- add unit tests for burst prediction
- allow compiling aetherum-kernel with `std` for tests

## Testing
- `cargo test --manifest-path aetherum-kernel/Cargo.toml --lib --target x86_64-unknown-linux-gnu`


------
https://chatgpt.com/codex/tasks/task_e_68766b49deac832b8097503e05b4294f